### PR TITLE
Add additional syntax for returning a function pointer from a function

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,15 @@
     </div>
 </div>
 <div>
+    <h2>As a <strong>return value from a function</strong>:</h2>
+    <div class="syntax"><code><span class="ckeyword">returnType</span> (*my_function(int, ...))(<span
+            class="cparameters">parameterTypes</span>);</code></div>
+    <div class="example"> (<a
+            href="http://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAKxAEZTUAHAvVAOwGdK0BbRvADaYA8mwDCCAIZtgmEAHIADPICUpDqgCuxZHPkB6AFQBqACKZkAycUzHJxgGaa2yFu2MEpBD5IDWmDjs2Yzw2AkxZYmNGa0keTHCo6XRjAFJFAEFjbJsCbU47R2dXVmDGVFDE4wB3QgQPAE9GW3QtACMhCEMVCFbNDswVADp0rOyAFQQ8QNqBATtXYwE8fyC7YmJJBpC2LAAPUOAilzc2IeNDfVG%2BgeMungaAfScT0ohKlR6boRVUgGYAEKjUZGMwWKw2QocBLGVAOY4ldiBTySbwEPy2dgtdpCNKZbLrYCaeJhIIpXL5QrfTDnS7XHG2B6PZBtZ7FU6PWi9BnRWI8X6A%2Bn9XFMlls17sR4AJm5wtsMU2/P%2BQMyoPMlmstnsWAckk0Am8L0RwWqU2Q9VaAWMbFQnkOtKumWpxlFrM8zl8stuCriApVGVGlRdklCEAAbhV0Co0gB2f3ZUFiSRzF1PI2nDyoYy5Yh4TBhrUIjPlSqYMijAnZUIeKaBZCSaGkGuYti2U14c3GDgAR00msCWiioUYmgIDorxmd9zT7NKjxLYTLXwZ0f%2BplT4uNEEUfonE8Tyfmnls6dK0Qqi6i7c7HAQWgEKR7fchx4nBOHo%2BMYeTmkx8IArOO%2BLZgklJMqekoLokED/rumSpDGpjAqqJjmA4oSFhBwQot4FLEAU9hYeepZRG0DaYCkb7uNIOz7EBGRToY4Gzuw7ykqE%2ByfF6PzAnGE4cLUBCdmxnEIfGBL1tCxiKCAIF5PhG5ilhnLKm%2BxiSbYtCyXhwSupuHJSqpwHZDqeoGtpoEKXp7psL4RljAhSHwYhyEZGqmDoa2hT1nMZHIL4RZnjhcn5MiCC2E%2Bmqwg4b7HtExCoGGeBYCkPrxIk9HOnpylcs6aW/M54k6byioXCVcT2Y5IKoR5GHeYefkBURwU6YEUgCPCcLNniYzxYlyUUeV6VlplPLZSxbDStx8p8gVAZ8cBxVpcY%2BjGIZgrOU5bk1Z5hY%2BQIjWBe4LWWQUcWMAlSUpT1BJpQkZY1HUWjeNI2w8BgeDofWpwcKNcqKW6CAetNQ1zWJE5LXylUufBmSqKQAgKP%2B8ikGwCi0CjqAKGIqRSkCeNdoOuhpFKfwY6QBAKMonykL4ID/ooCMKAALCjaNKJjCgo1wjOUxzahwLASC8PwQhkBQEAi4IZYoFYMiPAQxAeqQ6EGmWXAQG0VMo7wJIEKIAgNNrpD4DYJQFlwHPkIuiP8wwzClJb8O28jqPG1j8i42Tj2eMYewABwAGwALSB8z6ly0cECKx6Kgo3z1NqHTDNM/IrNu1bHvcyAvPazTttSmz7tcxTedqAWxAcKUIDM0AA%3D%3D"
+            target="_top">example code</a>)
+    </div>
+</div>
+<div>
     <h2>As a <strong>typedef</strong>:</h2>
     <div class="syntax"><code><span class="ckeyword">typedef returnType</span> (*<span
             class="cidentifier">typeName</span>)(<span class="cparameters">parameterTypes</span>);</code></div>


### PR DESCRIPTION
While the list is not supposed to be exhaustive, I felt the need to add the most backwards-looking syntax to the list, which is returning a function pointer from a function. This syntax has tripped up a number of my friends, so I felt it would be useful to include.