### PR TITLE
Update broken link to point at archived version

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
 </div>
 <div>
     <h2>As a <strong>cast</strong> (<a id="mindtribe_blog"
-                                       href="https://mindtribe.com/2015/06/do-c-callbacks-like-this-not-like-that/">but
+                                       href="https://web.archive.org/web/20160425131024/http://www.mindtribe.com:80/2015/06/do-c-callbacks-like-this-not-like-that/">but
         try not to cast functions</a>):</h2>
     <div class="syntax"><code>... (<span class="ckeyword">returnType</span> (*)(<span
             class="cparameters">parameterTypes</span>))my_expression ...</code></div>


### PR DESCRIPTION
The link in the "as a cast" section is broken, at least for me. It now redirects to Accenture's generic hardware consultancy page, which isn't particularly useful for function-pointer advice. This commit replaces it with a working link to the most recent capture on Archive.org's Wayback Machine that still shows the original content and which should stay up for a while.