### PR TITLE
update block syntax credit

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@
     work-friendly mirror.
 </div>
 <footer>By <a id="jerryryle" href="https://jerryryle.com"
-              title="Jerry's portfolio site">Jerry Ryle</a>, who fucking loves function pointers.<br/> Inspired by Mike
+              title="Jerry's portfolio site">Jerry Ryle</a>, who fucking loves function pointers.<br/> Inspired by Em
     Lazer-Walker's <a id="fucking_block_syntax" href="http://fuckingblocksyntax.com">Block Syntax</a>.<br/> <a
             id="fucking_github_repo"
             href="https://github.com/jerryryle/fuckingfunctionpointers.com"


### PR DESCRIPTION
Looks like the creator of the original Block Syntax site is now going by a different name (judging by both [fuckingblocksyntax.com](http://fuckingblocksyntax.com/) and the social links on [lazerwalker.com](https://lazerwalker.com/)) - I think this site should be updated accordingly.